### PR TITLE
Potential fix for code scanning alert no. 16: Incomplete regular expression for hostnames

### DIFF
--- a/literature/bibtex_to_json.py
+++ b/literature/bibtex_to_json.py
@@ -60,7 +60,7 @@ def extract_doi(entry: Dict) -> Optional[str]:
     
     # Remove URL prefix if present
     doi = re.sub(r'^https?://doi.org/', '', doi)
-    doi = re.sub(r'^https?://dx.doi.org/', '', doi)
+    doi = re.sub(r'^https?://dx\.doi\.org/', '', doi)
     
     return doi if doi else None
 


### PR DESCRIPTION
Potential fix for [https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/16](https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/16)

To fix the issue, escape the dot (`.`) in the regular expression so it matches a literal dot, not any character.  
Specifically, in line 63:
```python
doi = re.sub(r'^https?://dx.doi.org/', '', doi)
```
should become:
```python
doi = re.sub(r'^https?://dx\.doi\.org/', '', doi)
```
Only the two periods in `"dx.doi.org"` require escaping. No further code or imports are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
