### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_paper.yml
+++ b/.github/workflows/build_paper.yml
@@ -1,4 +1,6 @@
 name: Build Paper
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/2](https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow file to restrict the GITHUB_TOKEN permissions to the minimum required. Since this workflow only checks out code, installs dependencies, builds LaTeX, and uploads artifacts (but does NOT modify repository contents or interact with issues/PRs), the correct minimal permissions setting is likely `contents: read`. Place the following under the workflow’s name (after line 1):  
```yaml
permissions:
  contents: read
```  
This will apply to all jobs unless overridden by a job-specific `permissions` block.

You only need to edit `.github/workflows/build_paper.yml` by inserting the permissions block after the `name:` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
