### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,8 @@ jobs:
     name: Build Manuscript PDF
     runs-on: ubuntu-latest
     needs: create-release
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/15](https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/15)

The best way to fix the problem is to add an explicit `permissions:` block to the `build-paper` job inside `.github/workflows/release.yml`, restricting it to only the permissions needed. Based on the job steps, which only run code checkout, LaTeX build, and upload an artifact, the minimal required permission is `contents: read`. Thus, the fix is to add:
```yaml
permissions:
  contents: read
```
as a key under the job definition for `build-paper` (above the `steps:` block, after `needs:`), around line 128. No other code or imports need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
