### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,8 @@ jobs:
 
   docker-test:
     name: Test Docker Build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/14](https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/14)

To fix the problem, explicitly declare the `permissions` block to limit the permissions of the GITHUB_TOKEN. This can be done at the workflow root (`permissions:` near the top), which will apply to all jobs, or at the job level (under each job, e.g. under `docker-test:`). As only the `docker-test` job is flagged, the minimum fix is to add a `permissions:` block with `contents: read` immediately under the `docker-test:` job definition (i.e. after line 83). This provides the minimal read-only permission required for most workflows and adheres to the principle of least privilege. No methods, imports, or further definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
