### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-release
     if: startsWith(github.ref, 'refs/tags/v1.')
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/13](https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/13)

To fix the problem, you should add a `permissions` block to the `zenodo-deposit` job in `.github/workflows/release.yml`. Based on the job’s steps—primarily echoing information and, in production, interacting only with Zenodo via external APIs—it appears the job does not need write access to repository contents, packages, or other sensitive scopes. The minimal explicit permissions recommendation is generally `contents: read`, which allows safe access to repository contents (which is needed for the checkout step) without granting unnecessary write permissions. This block should be added directly beneath `runs-on` and above `steps` in the `zenodo-deposit` job. No other changes or imports are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
