### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/12](https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/12)

To fix the issue, we should set an explicit `permissions` key to limit the GITHUB_TOKEN scope for the workflow. Since the jobs only read source code for linting checks and do not modify repository contents or interact with issues/pull-requests, the minimal required permissions are `{ contents: read }`. This can be set either at the root of the workflow (applies to all jobs unless overridden) or individually for each job. The most maintainable fix is to set the `permissions` key at the workflow root right below the `name` field, which will apply to all jobs and ensure least privilege by default.

Files/regions to change: Insert the following under the workflow `name: Lint` at the top of `.github/workflows/lint.yml`.

No additional methods or imports are needed as this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
