### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,8 @@ jobs:
 
   test-slow:
     name: Slow Integration Tests
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 


### PR DESCRIPTION
Potential fix for [https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/11](https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/11)

To fix this issue, an explicit `permissions` block should be added to the `test-slow` job in the `.github/workflows/test.yml` workflow, limiting the GITHUB_TOKEN to the minimum permissions required. For jobs that only read repository contents and do not need to update anything on GitHub, specifying `permissions: contents: read` is sufficient. The fix is to add a block of code below `name: Slow Integration Tests` (on line 57) containing: 

```yaml
permissions:
  contents: read
```

No changes are necessary to the steps or other parts of the job; this patch simply restricts available permissions. No extra imports or methods are needed for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
