### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   coverage:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/3](https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/3)

To fix this issue, add a `permissions` block to the `coverage` job definition (or to the root of the workflow) that restricts the GITHUB_TOKEN permissions to the minimum required. For this workflow, `actions/checkout` requires `contents: read`, while `actions/upload-artifact` only requires default artifact permissions. If you upload to Codecov, the action does not need `write` permissions on the repository either. The safest minimal starting configuration is setting `permissions: contents: read` for the job. This should be added immediately before the `runs-on` line within the coverage job (line 11), to keep configuration granular. No additional imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
