### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/4](https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/4)

To fix the issue, the workflow or the specific job (“test”) must explicitly define a minimal permissions set for the GITHUB_TOKEN. Since none of the steps in the shown workflow require write access to the repository or to pull requests, the most restrictive and appropriate permission for this job is likely `contents: read`. This should be set by adding a `permissions:` block either at the root of the YAML (applies to all jobs), or inside the `jobs.test` block (applies only to this job). The best practice is to apply least-privilege at the root level if all jobs are fine with `contents: read`, or at the job level if only this job should be restricted. In this case, adding to the root level makes sense unless other jobs (not shown) require different permissions. The change is to insert the `permissions: contents: read` block after the `name:` and before the `on:` at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
