### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,6 @@
 name: Documentation
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/5](https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/5)

**General fix:**  
Explicitly set a `permissions` block at the root of the workflow file. This block will apply to all jobs that do not explicitly override the permissions.

**Detailed best fix:**  
Add the block:
```yaml
permissions:
  contents: read
```
after the `name:` field (before `on:`).  
This restricts GITHUB_TOKEN permission for all jobs to only allow reading repository contents (necessary for, e.g., `actions/checkout`). This is the minimal privilege needed by these jobs, as none of their steps appear to require write permissions.

**Files/regions/lines to change:**  
- File: `.github/workflows/docs.yml`
- Insert immediately below (or after) the `name: Documentation` line, i.e., after line 1.

**What is needed:**  
No extra methods, imports, or definitions—just the new YAML block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
