### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,6 +43,8 @@ jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.event_name == 'pull_request'
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/6](https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/6)

To fix the flagged problem, you should add a `permissions` block to the `dependency-review` job and set it to the minimum required privilege. Based on what the job does—checks out code and runs the `dependency-review-action`—it only needs to read the repository contents. This is achieved by including the following key-value pair under the job definition:
```yaml
permissions:
  contents: read
```
This should be added directly below the line `runs-on: ubuntu-latest` (line 45 in the snippet), and above `if: github.event_name == 'pull_request'`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
