### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,6 +59,8 @@ jobs:
   sbom-generation:
     name: Generate SBOM
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/8](https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/8)

To fix the problem, add a `permissions` block to the `sbom-generation` job in `.github/workflows/codeql.yml`. This block should set `contents: read`, which is the minimal privilege required to allow artifact upload and repository checkout, matching similar jobs in the workflow (like `dependency-review`). This change should be made directly above the `if:` key (or beneath `runs-on:`) in the `sbom-generation` job. No additional methods, imports, or definitions are required, just a small edit to the workflow YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
