### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   test:
     name: Test on Python ${{ matrix.python-version }}
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/9](https://github.com/olaflaitinen/llm-proteomics-hallucination/security/code-scanning/9)

To fix this issue, we need to add an explicit, minimal `permissions` block to the `test` job under the `jobs` section of `.github/workflows/test.yml`. Following the principle of least privilege and the way it's handled in other jobs, we'll add `contents: read` to the `test` job. No further changes are needed unless the job requires additional permissions for specific actions. The change will be made directly above the `runs-on` line (currently line 13) in the `test` job definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
